### PR TITLE
Replace custom csrf with ring-anti-forgery

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,12 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+
   :dependencies [[org.clojure/clojure     "1.5.1"]
                  [cheshire                "5.2.0"]
                  [ring/ring-core          "1.2.1"]
                  [ring/ring-jetty-adapter "1.2.1"]
+                 [ring/ring-anti-forgery  "0.3.1"]
                  [tailrecursion/cljson    "1.0.6"]
                  [tailrecursion/extype    "0.1.0"]
                  [tailrecursion/boot.ring "0.1.0"]])


### PR DESCRIPTION
- It's a breaking change. It won't work without wrap-anti-forgery
- A custom error-handler is necessary as the default response from
  ring-anti-forgery don't send a X-CSRF-Token header. Example:

``` clj
(defn custom-error-handler [request]
  {:status 403
   :headers {"Content-Type" "text/html"
             "X-CSRF-Token" *anti-forgery-token*}
   :body "<h1>Missing anti-forgery token</h1>"})

(wrap-anti-forgery {:error-handler custom-error-handler})
```
- Some modifications were necessary because the default response
  is not from castra. So no error handling on the client. I used the
  response status.
