### PR TITLE
Fix: secure-random-bytes doesn't exist on ring 1.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
                  [cheshire                "5.2.0"]
                  [ring/ring-core          "1.2.1"]
                  [ring/ring-jetty-adapter "1.2.1"]
+                 [crypto-random           "1.2.0"]
                  [tailrecursion/cljson    "1.0.6"]
                  [tailrecursion/extype    "0.1.0"]
                  [tailrecursion/boot.ring "0.2.0"]])

--- a/src/tailrecursion/castra/handler.clj
+++ b/src/tailrecursion/castra/handler.clj
@@ -8,7 +8,7 @@
 
 (ns tailrecursion.castra.handler
   (:require
-    [ring.middleware.session.cookie :as c]
+    [crypto.random                  :as c]
     [ring.util.request              :as q :refer [body-string]]
     [ring.util.codec                :as u :refer [url-decode base64-encode]]
     [clojure.set                    :as s :refer [intersection difference]]
@@ -18,7 +18,7 @@
 
 (defn csrf! []
   (let [tok1 (get-in @*request* [:headers "x-castra-csrf"])
-        tok! #(base64-encode (#'c/secure-random-bytes 16))]
+        tok! #(c/base64 16)]
     (swap! *session* (fn [x] (update-in x [:x-castra-csrf] #(or % (tok!)))))
     (when-not (and tok1 (= tok1 (:x-castra-csrf @*session*))) (throw (ex r/csrf)))))
 


### PR DESCRIPTION
Ring 1.3.0 removed ring.middleware.session.cookie/secure-random-bytes in
favor of crypto.random/bytes. Added a dependency on crypto-random that
can be removed when/if update the ring deps to 1.3.0.
