### PR TITLE
pass non-castra post requests to next handler

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -3,6 +3,7 @@
                   [ring/ring                  "1.2.1"  :scope "test"]
                   [org.clojure/clojure        "1.5.1"]
                   [ring/ring-core             "1.4.0"]
+                  [org.clojure/tools.logging  "0.3.1"]
                   [com.cognitect/transit-clj  "0.8.281"]
                   [com.cognitect/transit-cljs "0.8.225"]])
 

--- a/build.boot
+++ b/build.boot
@@ -9,7 +9,7 @@
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "3.0.0-alpha3")
+(def +version+ "3.0.0-alpha4")
 
 (bootlaces! +version+)
 


### PR DESCRIPTION
use the presence of x-castra-csrf header to determine if a post request is meant for castra, otherwise pass to next handler