### PR TITLE
introduce the state function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Web application RPC library for Clojure/Script and Ring.
 
 [](dependency)
 ```clojure
-[hoplon/castra "3.0.0-alpha3"] ;; latest release
+[hoplon/castra "3.1.0"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -8,7 +8,7 @@
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "3.0.0-alpha3")
+(def +version+ "3.1.0")
 
 (bootlaces! +version+)
 

--- a/src/castra/core.cljs
+++ b/src/castra/core.cljs
@@ -93,8 +93,8 @@
     (-> prom'
         (.done (fn [{:keys [headers body]}]
                  (set-session (get headers "X-Castra-Session"))
-                 (let [{:keys [ok error]} (resp body)]
-                   (or (and (not error) (.resolve prom ok))
+                 (let [{:keys [error] :as resp} (resp body)]
+                   (or (and (not error) (.resolve prom resp))
                        (.reject prom (doto (make-ex error) on-error))))))
         (.fail (fn [{:keys [headers body status status-text]}]
                  (.reject prom (doto (ajax-ex status status-text) on-error)))))
@@ -123,8 +123,8 @@
       (let [prom' (-> (ajax (with-default-opts opts) `[~endpoint ~@args])
                       (.done   #(do (when live?
                                       (reset! error nil)
-                                      (reset! state %))
-                                    (.resolve prom %)))
+                                      (reset! state (or (:state %) (:result %))))
+                                    (.resolve prom (:result %))))
                       (.fail   #(do (when live? (reset! error %))
                                     (.reject prom %)))
                       (.always #(when live? (swap! loading unload))))]


### PR DESCRIPTION
the state function, when passed to the castra middleware, further
segregates an application's command and query responsibilities.  by
assuming the duty of updating the application state, the state function
frees rpc commands to return their own results to the application.

the middleware first executes the command to mutate the application data,
then evaluates the state function to query it.  both the result and the
piggybacking application data are returned over the same http response
and mapped respectively to the call site and reference type.