### PR TITLE
Update transit-cljs to 0.8.239

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,7 +4,7 @@
                   [org.clojure/clojure        "1.5.1"]
                   [ring/ring-core             "1.4.0"]
                   [com.cognitect/transit-clj  "0.8.285"]
-                  [com.cognitect/transit-cljs "0.8.237"]
+                  [com.cognitect/transit-cljs "0.8.239"]
                   [cljsjs/jquery              "2.2.4-0"]])
 
 (require


### PR DESCRIPTION
The only change is that they now exclude `uuid?` from core, which throws a warning
```WARNING: uuid? already refers to: cljs.core/uuid? being replaced by: cognitect.transit/uuid?```
 when you are using a Clojure 1.9 alpha