### PR TITLE
refactor exception handling to close #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Web application RPC library for Clojure/Script and Ring.
 
 [](dependency)
 ```clojure
-[hoplon/castra "3.0.0-alpha7"] ;; latest release
+[hoplon/castra "3.0.0-alpha8"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -10,7 +10,7 @@
 (require
   '[adzerk.bootlaces :refer :all])
 
-(def +version+ "3.0.0-alpha7")
+(def +version+ "3.0.0-alpha8")
 
 (bootlaces! +version+)
 

--- a/src/castra/core.cljs
+++ b/src/castra/core.cljs
@@ -39,8 +39,8 @@
   [ex]
   (if (ex? ex)
     ex
-    (let [{:keys [status message data stack cause]} ex]
-      (doto (ex-info message (or data {}) cause)
+    (let [{:keys [status message stack case]} ex]
+      (doto (ex-info message ex cause)
         (aset "serverStack" stack)
         (aset "status" status)))))
 

--- a/src/castra/middleware.clj
+++ b/src/castra/middleware.clj
@@ -6,7 +6,7 @@
     [clojure.string                 :as string]
     [ring.util.request              :as q :refer [body-string]]
     [clojure.set                    :as s :refer [intersection difference]]
-    [castra.core                    :as r :refer [ex ex? dfl-ex *pre* *request* *session* *validate-only*]]
+    [castra.core                    :as r :refer [*pre* *request* *session* *validate-only*]]
     [clojure.stacktrace             :as u :refer [print-cause-trace print-stack-trace]])
   (:import
     [java.io File]
@@ -21,16 +21,14 @@
   (string/replace string ansi-pattern ""))
 
 (defn- ex->clj [e]
-  (let [e (if (ex? e) e (dfl-ex e))]
-    {:message (.getMessage e)
-     :data    (ex-data e)
-     :stack   (strip-ansi
-                (with-out-str
-                  (try (print-cause-trace e)
+  (->> (strip-ansi
+         (with-out-str
+           (try (print-cause-trace e)
+                (catch Throwable x
+                  (try (print-stack-trace e)
                        (catch Throwable x
-                         (try (print-stack-trace e)
-                              (catch Throwable x
-                                (printf "No stack trace: %s" (.getMessage x))))))))}))
+                         (printf "No stack trace: %s" (.getMessage x))))))))
+       (assoc (ex-data e) :stack stack)))
 
 (defn- csrf! []
   (when-not (get-in *request* [:headers "x-castra-csrf"])


### PR DESCRIPTION
@micha please review -- there might be additional cases i failed to take into account in this fix.  i don't recall what the originally-intended purpose of the `ex` fns was, but they seem unnecessary now.  currently left for compatibility reasons, but should we remove them entirely - are they considered part of the public api?

https://github.com/jumblerg/castra/blob/master/src/castra/core.clj#L16-L18

similarly, should we also dissoc `status`, `message`, `stack` and `case` from `ex`? also preserved for backwards compatibility in this commit.

https://github.com/jumblerg/castra/blob/master/src/castra/core.cljs#L42

