### PR TITLE
Return HTTP 500 error status when exception occurs

### DIFF
--- a/src/castra/middleware.clj
+++ b/src/castra/middleware.clj
@@ -122,11 +122,11 @@
                   *session*       (atom (:session req))
                   *validate-only* (= "true" (get-in req [:headers "x-castra-validate-only"]))]
           (let [h (headers req head {"Content-Type" "application/json;charset=utf-8"})
-                f #(do (csrf!) (do-rpc (vars) (expression body-keys req)))
-                d (try (response body-keys req {:result (f) :state (when state-fn (state-fn))})
-                       (catch Throwable e
-                         (response body-keys req {:error (ex->clj e)})))]
-            {:status 200, :headers h, :body d, :session @*session*}))))))
+                r {:status 200, :headers h, :session @*session*}
+                f #(do (csrf!) (do-rpc (vars) (expression body-keys req)))]
+            (try (assoc r :body (response body-keys req {:result (f) :state (when state-fn (state-fn))}))
+                 (catch Throwable e
+                   (assoc r :status 500 :body (response body-keys req {:error (ex->clj e)}))))))))))
 
 ;; AJAX Crawling Middleware ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Currently middleware return status *200* even when exception occurs:

```
juergen@samson:~ → curl -X POST -d '["~$modern-cljs.core/test2",12,2,3]' -v -H "Content-Type: application/json"  -H "x-castra-csrf: true" http://localhost:8888/test1
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8888 (#0)
> POST /test1 HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.54.1
> Accept: */*
> Content-Type: application/json
> x-castra-csrf: true
> Content-Length: 35
> 
* upload completely sent off: 35 out of 35 bytes
< HTTP/1.1 200 OK
< Date: Sat, 22 Jul 2017 11:53:29 GMT
< X-Castra-Tunnel: transit
< Content-Type: application/json
< Content-Length: 3492
< Server: Jetty(9.2.10.v20150310)
< 
["^ ","~:error",["^ ","~:message","Server error.","~:data",["^ ","~:castra.core/exception",true],
...

```
Using this commit:
```

juergen@samson:~/tmp/castra → curl -X POST -d '["~$modern-cljs.core/test2",12,2,3]' -v -H "Content-Type: application/json"  -H "x-castra-csrf: true" http://localhost:8888/test1
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8888 (#0)
> POST /test1 HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.54.1
> Accept: */*
> Content-Type: application/json
> x-castra-csrf: true
> Content-Length: 35
> 
* upload completely sent off: 35 out of 35 bytes
< HTTP/1.1 500 Server Error
< Date: Sat, 22 Jul 2017 13:03:13 GMT
< X-Castra-Tunnel: transit
< Content-Type: application/json;charset=utf-8
< Content-Length: 3330
< Server: Jetty(9.2.10.v20150310)
< 
["^ ","~:error",["^ ","~:message","Server error.","~:data",["^ ","~:castra.core/exception",true],
```